### PR TITLE
Fix for typo and environment effect added twice.

### DIFF
--- a/src/response_distributions.jl
+++ b/src/response_distributions.jl
@@ -61,11 +61,11 @@ type InverseGaussianResponse <: ResponseDistribution
   λ::Float64
 
   # to make sure λ is greater than 0
-  function InverseGaussianResponse(α::Float64)
+  function InverseGaussianResponse(λ::Float64)
     if(λ <= 0)
       error("λ must be greater than zero in a inverse Gaussian distribution!")
     else
-      new(α)
+      new(λ)
     end
   end
 


### PR DESCRIPTION
(1) In response_distributions.jl: fixed variable name typo in InverseGaussianResponse().

(2) In generate_simulations.jl when NormalResponse and variance components have been selected, the random environment effect was added twice, once in calc_randeff() and once in calc_trait(). This is fixed so that it is only added in calc_randeff().